### PR TITLE
Added overlooked function parameter and argument cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
   <div>
     <h2>As a <strong>method parameter</strong>:</h2>
     <code>
-      - (void)someMethodThatTakesABlock:(<span class='return'>returnType</span> (^)(<span class='parameter-types'>parameterTypes</span>))<span class='name'>blockName</span> {...}
+      - (void)someMethodThatTakesABlock:(<span class='return'>returnType</span> (^)(<span class='parameter-types'>parameterTypes</span>))<span class='name'>blockName</span>;
     </code>
   </div>
 
@@ -113,6 +113,20 @@
     <h2>As an <strong>argument to a method call</strong>:</h2>
     <code>
       [someObject someMethodThatTakesABlock: ^<span class='return'>returnType</span> (<span class='parameters'>parameters</span>) {...}];
+    </code>
+  </div>
+
+  <div>
+    <h2>As a <strong>function parameter</strong>:</h2>
+    <code>
+      void someFunctionThatTakesABlock(<span class='return'>returnType</span> (^<span class='name'>blockName</span>)(<span class='parameter-types'>parameterTypes</span>));
+    </code>
+  </div>
+
+  <div>
+    <h2>As an <strong>argument to a function call</strong>:</h2>
+    <code>
+      someFunctionThatTakesABlock(^<span class='return'>returnType</span> (<span class='parameters'>parameters</span>) {...});
     </code>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -117,20 +117,6 @@
   </div>
 
   <div>
-    <h2>As a <strong>function parameter</strong>:</h2>
-    <code>
-      void someFunctionThatTakesABlock(<span class='return'>returnType</span> (^<span class='name'>blockName</span>)(<span class='parameter-types'>parameterTypes</span>));
-    </code>
-  </div>
-
-  <div>
-    <h2>As an <strong>argument to a function call</strong>:</h2>
-    <code>
-      someFunctionThatTakesABlock(^<span class='return'>returnType</span> (<span class='parameters'>parameters</span>) {...});
-    </code>
-  </div>
-
-  <div>
     <h2>As a <strong>typedef</strong>:</h2>
     <code>
       typedef <span class='return'>returnType</span> (^<span class='name'>TypeName</span>)(<span class='parameter-types'>parameterTypes</span>);<br/>


### PR DESCRIPTION
Additionally, I swapped `{…}` for `;` in method parameter case to avoid
confusion with other cases where the `{…}` designates the block body.
