### PR TITLE
Added a fallback font

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
     code {
       display: block;
-      font-family: Monaco, Menlo;
+      font-family: Monaco, Menlo, monospace;
       font-size: 20px;
       margin-bottom: 3em;
       margin-left: 40px;


### PR DESCRIPTION
I was a bit startled when I first saw the code examples in default `serif`, since I have neither of the fonts specified. So I added an acceptable fallback that should work everywhere unless explicitly broken.
